### PR TITLE
Configure styled components as React component style tool

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,5 +2,8 @@
   "extends": [
     "eslint-config-airbnb"
   ],
-  "parser": "babel-eslint"
+  "parser": "babel-eslint",
+  "rules": {
+    "react/jsx-props-no-spreading": ["off"]
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -885,6 +885,24 @@
       "resolved": "https://registry.npmjs.org/@csstools/convert-colors/-/convert-colors-1.4.0.tgz",
       "integrity": "sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw=="
     },
+    "@emotion/is-prop-valid": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.3.tgz",
+      "integrity": "sha512-We7VBiltAJ70KQA0dWkdPMXnYoizlxOXpvtjmu5/MBnExd+u0PGgV27WCYanmLAbCwAU30Le/xA0CQs/F/Otig==",
+      "requires": {
+        "@emotion/memoize": "0.7.3"
+      }
+    },
+    "@emotion/memoize": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.3.tgz",
+      "integrity": "sha512-2Md9mH6mvo+ygq1trTeVp2uzAKwE2P7In0cRpD/M9Q70aH8L+rxMLbb3JCN2JoSWsV2O+DdFjfbbXoMoLBczow=="
+    },
+    "@emotion/unitless": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.4.tgz",
+      "integrity": "sha512-kBa+cDHOR9jpRJ+kcGMsysrls0leukrm68DmFQoMIWQcXdr2cZvyvypWuGYT7U+9kAExUE7+T7r6G3C3A6L8MQ=="
+    },
     "@webassemblyjs/ast": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",
@@ -1502,6 +1520,17 @@
         "object.assign": "^4.1.0"
       }
     },
+    "babel-plugin-styled-components": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.6.tgz",
+      "integrity": "sha512-gyQj/Zf1kQti66100PhrCRjI5ldjaze9O0M3emXRPAN80Zsf8+e1thpTpaXJXVHXtaM4/+dJEgZHyS9Its+8SA==",
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.0.0",
+        "@babel/helper-module-imports": "^7.0.0",
+        "babel-plugin-syntax-jsx": "^6.18.0",
+        "lodash": "^4.17.11"
+      }
+    },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
@@ -1844,6 +1873,11 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+    },
+    "camelize": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
+      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
     },
     "caniuse-lite": {
       "version": "1.0.30000999",
@@ -2277,6 +2311,11 @@
         "postcss": "^7.0.5"
       }
     },
+    "css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU="
+    },
     "css-has-pseudo": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/css-has-pseudo/-/css-has-pseudo-0.10.0.tgz",
@@ -2328,6 +2367,23 @@
       "integrity": "sha512-MTu6+tMs9S3EUqzmqLXEcgNRbNkkD/TGFvowpeoWJn5Vfq7FMgsmRQs9X5NXAURiOBmOxm/lLjsDNXDE6k9bhg==",
       "requires": {
         "postcss": "^7.0.5"
+      }
+    },
+    "css-to-react-native": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-2.3.2.tgz",
+      "integrity": "sha512-VOFaeZA053BqvvvqIA8c9n0+9vFppVBAHCp6JgFTtTMU3Mzi+XnelJ9XC9ul3BqFzZyQ5N+H0SnwsWT2Ebchxw==",
+      "requires": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^3.3.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+        }
       }
     },
     "cssdb": {
@@ -4369,6 +4425,11 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
+    "is-what": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-3.3.1.tgz",
+      "integrity": "sha512-seFn10yAXy+yJlTRO+8VfiafC+0QJanGLMPTBWLrJm/QPauuchy0UXh8B6H5o9VA8BAzk0iYievt6mNp6gfaqA=="
+    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -4640,6 +4701,11 @@
         "safe-buffer": "^5.1.2"
       }
     },
+    "memoize-one": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
+      "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
+    },
     "memory-fs": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
@@ -4647,6 +4713,14 @@
       "requires": {
         "errno": "^0.1.3",
         "readable-stream": "^2.0.1"
+      }
+    },
+    "merge-anything": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/merge-anything/-/merge-anything-2.4.1.tgz",
+      "integrity": "sha512-dYOIAl9GFCJNctSIHWOj9OJtarCjsD16P8ObCl6oxrujAG+kOvlwJuOD9/O9iYZ9aTi1RGpGTG9q9etIvuUikQ==",
+      "requires": {
+        "is-what": "^3.3.1"
       }
     },
     "merge-stream": {
@@ -6944,6 +7018,26 @@
       "requires": {
         "loader-utils": "^1.2.3",
         "schema-utils": "^2.0.1"
+      }
+    },
+    "styled-components": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-4.4.0.tgz",
+      "integrity": "sha512-xQ6vTI/0zNjZ1BBDRxyjvBddrxhQ3DxjeCdaLM1lSn5FDnkTOQgRkmWvcUiTajqc5nJqKVl+7sUioMqktD0+Zw==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/traverse": "^7.0.0",
+        "@emotion/is-prop-valid": "^0.8.1",
+        "@emotion/unitless": "^0.7.0",
+        "babel-plugin-styled-components": ">= 1",
+        "css-to-react-native": "^2.2.2",
+        "memoize-one": "^5.0.0",
+        "merge-anything": "^2.2.4",
+        "prop-types": "^15.5.4",
+        "react-is": "^16.6.0",
+        "stylis": "^3.5.0",
+        "stylis-rule-sheet": "^0.0.10",
+        "supports-color": "^5.5.0"
       }
     },
     "styled-jsx": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   "dependencies": {
     "next": "9.1.1",
     "react": "16.10.2",
-    "react-dom": "16.10.2"
+    "react-dom": "16.10.2",
+    "styled-components": "4.4.0"
   },
   "devDependencies": {
     "babel-eslint": "10.0.3",

--- a/src/atoms/Example/index.jsx
+++ b/src/atoms/Example/index.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import Style from './styles';
+
+function Example() {
+  return (
+    <Style.Text>Example Component</Style.Text>
+  );
+}
+
+export default Example;

--- a/src/atoms/Example/styles.js
+++ b/src/atoms/Example/styles.js
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+
+const Text = styled.p`
+  font-size: 1.333rem;
+  line-height: 1.5rem;
+  margin: 0;
+`;
+
+export default {
+  Text,
+};

--- a/src/bosons/globalCSS/index.jsx
+++ b/src/bosons/globalCSS/index.jsx
@@ -1,0 +1,10 @@
+import { createGlobalStyle } from 'styled-components';
+import normalize from './normalize';
+import reset from './reset';
+
+const globalCSS = createGlobalStyle`
+  ${reset}
+  ${normalize}
+`;
+
+export default globalCSS;

--- a/src/bosons/globalCSS/normalize.js
+++ b/src/bosons/globalCSS/normalize.js
@@ -1,0 +1,355 @@
+import { css } from 'styled-components';
+
+const normalize = css`
+  /*! normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css */
+
+  /* Document
+    ========================================================================== */
+
+  /**
+    * 1. Correct the line height in all browsers.
+    * 2. Prevent adjustments of font size after orientation changes in iOS.
+    */
+
+  html {
+    line-height: 1.15; /* 1 */
+    -webkit-text-size-adjust: 100%; /* 2 */
+  }
+
+  /* Sections
+    ========================================================================== */
+
+  /**
+    * Remove the margin in all browsers.
+    */
+
+  body {
+    margin: 0;
+  }
+
+  /**
+    * Render the main element consistently in IE.
+    */
+
+  main {
+    display: block;
+  }
+
+  /**
+    * Correct the font size and margin on 'h1' elements within 'section' and
+    * 'article' contexts in Chrome, Firefox, and Safari.
+    */
+
+  h1 {
+    font-size: 2em;
+    margin: 0.67em 0;
+  }
+
+  /* Grouping content
+    ========================================================================== */
+
+  /**
+    * 1. Add the correct box sizing in Firefox.
+    * 2. Show the overflow in Edge and IE.
+    */
+
+  hr {
+    box-sizing: content-box; /* 1 */
+    height: 0; /* 1 */
+    overflow: visible; /* 2 */
+  }
+
+  /**
+    * 1. Correct the inheritance and scaling of font size in all browsers.
+    * 2. Correct the odd 'em' font sizing in all browsers.
+    */
+
+  pre {
+    font-family: monospace, monospace; /* 1 */
+    font-size: 1em; /* 2 */
+  }
+
+  /* Text-level semantics
+  ========================================================================== */
+
+  /**
+    * Remove the gray background on active links in IE 10.
+    */
+
+  a {
+    background-color: transparent;
+  }
+
+  /**
+    * 1. Remove the bottom border in Chrome 57-
+    * 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari.
+    */
+
+  abbr[title] {
+    border-bottom: none; /* 1 */
+    text-decoration: underline; /* 2 */
+    text-decoration: underline dotted; /* 2 */
+  }
+
+  /**
+    * Add the correct font weight in Chrome, Edge, and Safari.
+    */
+
+  b,
+  strong {
+    font-weight: bolder;
+  }
+
+  /**
+    * 1. Correct the inheritance and scaling of font size in all browsers.
+    * 2. Correct the odd 'em' font sizing in all browsers.
+    */
+
+  code,
+  kbd,
+  samp {
+    font-family: monospace, monospace; /* 1 */
+    font-size: 1em; /* 2 */
+  }
+
+  /**
+    * Add the correct font size in all browsers.
+    */
+
+  small {
+    font-size: 80%;
+  }
+
+  /**
+    * Prevent 'sub' and 'sup' elements from affecting the line height in
+    * all browsers.
+  */
+
+  sub,
+  sup {
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+  }
+
+  sub {
+    bottom: -0.25em;
+  }
+
+  sup {
+    top: -0.5em;
+  }
+
+  /* Embedded content
+    ========================================================================== */
+
+  /**
+    * Remove the border on images inside links in IE 10.
+    */
+
+  img {
+    border-style: none;
+  }
+
+  /* Forms
+    ========================================================================== */
+
+  /**
+    * 1. Change the font styles in all browsers.
+    * 2. Remove the margin in Firefox and Safari.
+    */
+
+  button,
+  input,
+  optgroup,
+  select,
+  textarea {
+    font-family: inherit; /* 1 */
+    font-size: 100%; /* 1 */
+    line-height: 1.15; /* 1 */
+    margin: 0; /* 2 */
+  }
+
+  /**
+    * Show the overflow in IE.
+    * 1. Show the overflow in Edge.
+    */
+
+  button,
+  input { /* 1 */
+    overflow: visible;
+  }
+
+  /**
+    * Remove the inheritance of text transform in Edge, Firefox, and IE.
+    * 1. Remove the inheritance of text transform in Firefox.
+  */
+
+  button,
+  select { /* 1 */
+    text-transform: none;
+  }
+
+  /**
+    * Correct the inability to style clickable types in iOS and Safari.
+    */
+
+  button,
+  [type="button"],
+  [type="reset"],
+  [type="submit"] {
+    -webkit-appearance: button;
+  }
+
+  /**
+    * Remove the inner border and padding in Firefox.
+    */
+
+  button::-moz-focus-inner,
+  [type="button"]::-moz-focus-inner,
+  [type="reset"]::-moz-focus-inner,
+  [type="submit"]::-moz-focus-inner {
+    border-style: none;
+    padding: 0;
+  }
+
+  /**
+    * Restore the focus styles unset by the previous rule.
+    */
+
+  button:-moz-focusring,
+  [type="button"]:-moz-focusring,
+  [type="reset"]:-moz-focusring,
+  [type="submit"]:-moz-focusring {
+    outline: 1px dotted ButtonText;
+  }
+
+  /**
+    * Correct the padding in Firefox.
+    */
+
+  fieldset {
+    padding: 0.35em 0.75em 0.625em;
+  }
+
+  /**
+    * 1. Correct the text wrapping in Edge and IE.
+    * 2. Correct the color inheritance from 'fieldset' elements in IE.
+    * 3. Remove the padding so developers are not caught out when they zero out
+    *    'fieldset' elements in all browsers.
+    */
+
+  legend {
+    box-sizing: border-box; /* 1 */
+    color: inherit; /* 2 */
+    display: table; /* 1 */
+    max-width: 100%; /* 1 */
+    padding: 0; /* 3 */
+    white-space: normal; /* 1 */
+  }
+
+  /**
+    * Add the correct vertical alignment in Chrome, Firefox, and Opera.
+    */
+
+  progress {
+    vertical-align: baseline;
+  }
+
+  /**
+    * Remove the default vertical scrollbar in IE 10+.
+    */
+
+  textarea {
+    overflow: auto;
+  }
+
+  /**
+    * 1. Add the correct box sizing in IE 10.
+    * 2. Remove the padding in IE 10.
+    */
+
+  [type="checkbox"],
+  [type="radio"] {
+    box-sizing: border-box; /* 1 */
+    padding: 0; /* 2 */
+  }
+
+  /**
+    * Correct the cursor style of increment and decrement buttons in Chrome.
+    */
+
+  [type="number"]::-webkit-inner-spin-button,
+  [type="number"]::-webkit-outer-spin-button {
+    height: auto;
+  }
+
+  /**
+    * 1. Correct the odd appearance in Chrome and Safari.
+    * 2. Correct the outline style in Safari.
+    */
+
+  [type="search"] {
+    -webkit-appearance: textfield; /* 1 */
+    outline-offset: -2px; /* 2 */
+  }
+
+  /**
+    * Remove the inner padding in Chrome and Safari on macOS.
+    */
+
+  [type="search"]::-webkit-search-decoration {
+    -webkit-appearance: none;
+  }
+
+  /**
+    * 1. Correct the inability to style clickable types in iOS and Safari.
+    * 2. Change font properties to 'inherit' in Safari.
+    */
+
+  ::-webkit-file-upload-button {
+    -webkit-appearance: button; /* 1 */
+    font: inherit; /* 2 */
+  }
+
+  /* Interactive
+    ========================================================================== */
+
+  /**
+    * Add the correct display in Edge, IE 10+, and Firefox.
+    */
+
+  details {
+    display: block;
+  }
+
+  /**
+    * Add the correct display in all browsers.
+    */
+
+  summary {
+    display: list-item;
+  }
+
+  /* Misc
+    ========================================================================== */
+
+  /**
+    * Add the correct display in IE 10+.
+    */
+
+  template {
+    display: none;
+  }
+
+  /**
+    * Add the correct display in IE 10.
+    */
+
+  [hidden] {
+    display: none;
+  }
+`;
+
+export default normalize;

--- a/src/bosons/globalCSS/reset.js
+++ b/src/bosons/globalCSS/reset.js
@@ -1,0 +1,51 @@
+import { css } from 'styled-components';
+
+const reset = css`
+  /*! http://meyerweb.com/eric/tools/css/reset/ v2.0 | 20110126 License: none (public domain) */
+
+  html, body, div, span, applet, object, iframe,
+  h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+  a, abbr, acronym, address, big, cite, code,
+  del, dfn, em, img, ins, kbd, q, s, samp,
+  small, strike, strong, sub, sup, tt, var,
+  b, u, i, center,
+  dl, dt, dd, ol, ul, li,
+  fieldset, form, label, legend,
+  table, caption, tbody, tfoot, thead, tr, th, td,
+  article, aside, canvas, details, embed, 
+  figure, figcaption, footer, header, hgroup, 
+  menu, nav, output, ruby, section, summary,
+  time, mark, audio, video {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    font-size: 100%;
+    font: inherit;
+    vertical-align: baseline;
+  }
+  /* HTML5 display-role reset for older browsers */
+  article, aside, details, figcaption, figure, 
+  footer, header, hgroup, menu, nav, section {
+    display: block;
+  }
+  body {
+    line-height: 1;
+  }
+  ol, ul {
+    list-style: none;
+  }
+  blockquote, q {
+    quotes: none;
+  }
+  blockquote:before, blockquote:after,
+  q:before, q:after {
+    content: '';
+    content: none;
+  }
+  table {
+    border-collapse: collapse;
+    border-spacing: 0;
+  }
+`;
+
+export default reset;

--- a/src/bosons/themes/base/index.js
+++ b/src/bosons/themes/base/index.js
@@ -1,0 +1,3 @@
+export default {
+
+};

--- a/src/bosons/themes/index.js
+++ b/src/bosons/themes/index.js
@@ -1,0 +1,5 @@
+import base from './base';
+
+export default {
+  base,
+};

--- a/src/pages/_app.jsx
+++ b/src/pages/_app.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import App, { Container } from 'next/app';
+
+class MyApp extends App {
+  static async getInitialProps({ Component, ctx }) {
+    let pageProps = {};
+    if (ctx) {
+      pageProps = Component.getInitialProps ? await Component.getInitialProps(ctx) : {};
+    }
+
+    return { pageProps };
+  }
+
+  render() {
+    const {
+      Component, pageProps,
+    } = this.props;
+
+    return (
+      <Container>
+        <Component {...pageProps} />
+      </Container>
+    );
+  }
+}
+
+export default MyApp;

--- a/src/pages/_app.jsx
+++ b/src/pages/_app.jsx
@@ -1,5 +1,9 @@
 import React from 'react';
 import App, { Container } from 'next/app';
+import { ThemeProvider } from 'styled-components';
+
+import GlobalCSS from '../bosons/globalCSS';
+import themes from '../bosons/themes';
 
 class MyApp extends App {
   static async getInitialProps({ Component, ctx }) {
@@ -17,9 +21,12 @@ class MyApp extends App {
     } = this.props;
 
     return (
-      <Container>
-        <Component {...pageProps} />
-      </Container>
+      <ThemeProvider theme={themes.base}>
+        <Container>
+          <GlobalCSS />
+          <Component {...pageProps} />
+        </Container>
+      </ThemeProvider>
     );
   }
 }

--- a/src/pages/_document.jsx
+++ b/src/pages/_document.jsx
@@ -1,10 +1,15 @@
 import React from 'react';
 import Document, { Head, Main, NextScript } from 'next/document';
+import { ServerStyleSheet } from 'styled-components';
 
 export default class extends Document {
   static async getInitialProps(ctx) {
+    const { renderPage } = ctx;
+    const sheet = new ServerStyleSheet();
+    const page = renderPage((App) => (props) => sheet.collectStyles(<App {...props} />));
+    const styleTags = sheet.getStyleElement();
     const initialProps = await Document.getInitialProps(ctx);
-    return { ...initialProps };
+    return { ...initialProps, ...page, styleTags };
   }
 
   render() {
@@ -12,6 +17,7 @@ export default class extends Document {
       <html lang="br">
         <Head>
           <meta name="viewport" content="width=device-width, initial-scale=1" />
+          {this.props.styleTags}
         </Head>
         <body>
           <Main />

--- a/src/pages/_document.jsx
+++ b/src/pages/_document.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import Document, { Head, Main, NextScript } from 'next/document';
+
+export default class extends Document {
+  static async getInitialProps(ctx) {
+    const initialProps = await Document.getInitialProps(ctx);
+    return { ...initialProps };
+  }
+
+  render() {
+    return (
+      <html lang="br">
+        <Head>
+          <meta name="viewport" content="width=device-width, initial-scale=1" />
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </html>
+    );
+  }
+}

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -1,8 +1,11 @@
 import React from 'react';
 
+import Example from '../atoms/Example';
+
 function Home() {
   return (
     <div>
+      <Example />
       <h1>Hello World ! (Home)</h1>
       <a href="about">Ir para About</a>
     </div>


### PR DESCRIPTION
# Description

Configure [Styled Components](https://www.styled-components.com/) as React Component style tool.

Was applied the [`styled-reset`](https://www.npmjs.com/package/styled-reset) and [`styled-normalize`](https://www.npmjs.com/package/styled-normalize) as GlobalCSS, no using dependencies because the `styled-reset` has so much sub-dependencies as you can see in the picture above:

<img width="314" alt="Captura de Tela 2019-10-26 às 22 45 55" src="https://user-images.githubusercontent.com/30807170/67628840-66ef4e80-f842-11e9-9d2b-e3e56a743baf.png">

[Anvaka NPM for styled-reset](http://npm.anvaka.com/#/view/2d/styled-reset)

And to make default was chose no use dependency for `styled-normalized` too.

In Additional, was shut off `react/jsx-props-no-spreading` as linter rules because was considered not wrong use spread in props.

# How to test

- Create a new component which use `styled-components` and that should be rendered.
- All styled components should receive theme as prop.
- When open some page, the globalCSS and all css from components rendered should be marked in `<style></style>`

