### PR TITLE
Initialize base theme with breakpoints e widths

### DIFF
--- a/src/atoms/Example/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/src/atoms/Example/__tests__/__snapshots__/index.spec.jsx.snap
@@ -7,6 +7,12 @@ exports[`testing: Example component should render correctly 1`] = `
   margin: 0;
 }
 
+@media (min-width:576px) {
+  .c0 {
+    margin: 24px;
+  }
+}
+
 <p
   className="c0"
 >

--- a/src/atoms/Example/__tests__/__snapshots__/index.spec.jsx.snap
+++ b/src/atoms/Example/__tests__/__snapshots__/index.spec.jsx.snap
@@ -9,7 +9,8 @@ exports[`testing: Example component should render correctly 1`] = `
 
 @media (min-width:576px) {
   .c0 {
-    margin: 24px;
+    margin: 24px auto;
+    max-width: 760px;
   }
 }
 

--- a/src/atoms/Example/__tests__/index.spec.jsx
+++ b/src/atoms/Example/__tests__/index.spec.jsx
@@ -1,11 +1,15 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import { shallow } from 'enzyme';
+
 import Example from '../index';
+import withTheme from '../../../hoc/withTheme';
+
+const WrappedExample = withTheme(Example);
 
 describe('testing: Example component', () => {
   test('should render correctly', () => {
-    const ExampleComponent = renderer.create(<Example />).toJSON();
+    const ExampleComponent = renderer.create(<WrappedExample />).toJSON();
     expect(ExampleComponent).toMatchSnapshot();
   });
   test('should has the example text', () => {

--- a/src/atoms/Example/styles.js
+++ b/src/atoms/Example/styles.js
@@ -4,6 +4,10 @@ const Text = styled.p`
   font-size: 1.333rem;
   line-height: 1.5rem;
   margin: 0;
+
+  ${({ theme: { breakpoints } }) => breakpoints.sm} {
+    margin: 24px;
+  }
 `;
 
 export default {

--- a/src/atoms/Example/styles.js
+++ b/src/atoms/Example/styles.js
@@ -6,7 +6,8 @@ const Text = styled.p`
   margin: 0;
 
   ${({ theme: { breakpoints } }) => breakpoints.sm} {
-    margin: 24px;
+    margin: 24px auto;
+    max-width: ${({ theme: { widths } }) => widths.narrow};
   }
 `;
 

--- a/src/bosons/themes/base/breakpoints.js
+++ b/src/bosons/themes/base/breakpoints.js
@@ -1,0 +1,13 @@
+/**
+ * Based in Mobile First always
+ */
+
+const breakpoints = {
+  xs: '@media (min-width: 0px)',
+  sm: '@media (min-width: 576px)',
+  md: '@media (min-width: 768px)',
+  lg: '@media (min-width: 992px)',
+  xl: '@media (min-width: 1200px)',
+};
+
+export default breakpoints;

--- a/src/bosons/themes/base/index.js
+++ b/src/bosons/themes/base/index.js
@@ -1,5 +1,7 @@
 import breakpoints from './breakpoints';
+import widths from './widths';
 
 export default {
   breakpoints,
+  widths,
 };

--- a/src/bosons/themes/base/index.js
+++ b/src/bosons/themes/base/index.js
@@ -1,3 +1,5 @@
-export default {
+import breakpoints from './breakpoints';
 
+export default {
+  breakpoints,
 };

--- a/src/bosons/themes/base/widths.js
+++ b/src/bosons/themes/base/widths.js
@@ -1,0 +1,5 @@
+const widths = {
+  max: '1152px',
+};
+
+export default widths;

--- a/src/hoc/withTheme/index.jsx
+++ b/src/hoc/withTheme/index.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { ThemeProvider } from 'styled-components';
+import themes from '../../bosons/themes';
+
+const Wrapped = (Component) => (props) => (
+  <ThemeProvider theme={themes.base}>
+    <Component {...props} />
+  </ThemeProvider>
+);
+
+export default Wrapped;


### PR DESCRIPTION
# Description 

Initialize base theme with breakpoints e widths. And was applied to example component.

# How to test

- Executing `npm run test` the snapshot should pass because they have breakpoint and width from theme.